### PR TITLE
Use separate client and server API keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN pip install --no-cache-dir -e .
 ENV DJANGO_SETTINGS_MODULE "config.settings.production"
 
 COPY . /app
-RUN GOOGLE_PLACES_API_KEY=placeholder SECRET_KEY=placeholder ALLOWED_HOSTS=placeholder python manage.py collectstatic --noinput
+RUN GOOGLE_PLACES_CLIENT_API_KEY=placeholder GOOGLE_PLACES_SERVER_API_KEY=placeholder SECRET_KEY=placeholder ALLOWED_HOSTS=placeholder python manage.py collectstatic --noinput
 CMD ["config.wsgi:application"]

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -121,7 +121,8 @@ USE_L10N = True
 
 USE_TZ = True
 
-PLACES_API_KEY = env.str("GOOGLE_PLACES_API_KEY", "REPLACE_ME")
+CLIENT_PLACES_API_KEY = env.str("GOOGLE_PLACES_CLIENT_API_KEY", "REPLACE_ME")
+SERVER_PLACES_API_KEY = env.str("GOOGLE_PLACES_SERVER_API_KEY", "REPLACE_ME")
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -19,4 +19,5 @@ if SENTRY_DSN:
         dsn=SENTRY_DSN, integrations=[DjangoIntegration()], send_default_pii=True
     )
 
-PLACES_API_KEY = env.str("GOOGLE_PLACES_API_KEY")
+CLIENT_PLACES_API_KEY = env.str("GOOGLE_PLACES_CLIENT_API_KEY")
+SERVER_PLACES_API_KEY = env.str("GOOGLE_PLACES_SERVER_API_KEY")

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -13,4 +13,5 @@ PASSWORD_HASHERS = ("django.contrib.auth.hashers.MD5PasswordHasher",)
 ENV_HOSTS = [host for host in env.str("ALLOWED_HOSTS", "").split(",") if host]
 ALLOWED_HOSTS = ENV_HOSTS + ["localhost", ".localhost", "127.0.0.1", "0.0.0.0"]
 
-PLACES_API_KEY = "TEST_API_KEY"
+CLIENT_PLACES_API_KEY = "TEST_API_KEY"
+SERVER_PLACES_API_KEY = "TEST_API_KEY"

--- a/higher_health/context_processors.py
+++ b/higher_health/context_processors.py
@@ -2,4 +2,4 @@ from django.conf import settings
 
 
 def api_keys(request):
-    return {"PLACES_API_KEY": settings.PLACES_API_KEY}
+    return {"PLACES_API_KEY": settings.CLIENT_PLACES_API_KEY}

--- a/higher_health/forms.py
+++ b/higher_health/forms.py
@@ -180,7 +180,7 @@ class HealthCheckQuestionnaire(forms.Form):
                 if data.get("latitude") == "" or data.get("longitude") == "":
                     querystring = urlencode(
                         {
-                            "key": settings.PLACES_API_KEY,
+                            "key": settings.SERVER_PLACES_API_KEY,
                             "input": data["address"],
                             "language": "en",
                             "components": "country:za",
@@ -193,7 +193,7 @@ class HealthCheckQuestionnaire(forms.Form):
                     if location["predictions"]:
                         querystring = urlencode(
                             {
-                                "key": settings.PLACES_API_KEY,
+                                "key": settings.SERVER_PLACES_API_KEY,
                                 "place_id": location["predictions"][0]["place_id"],
                                 "language": "en",
                                 "fields": "geometry",


### PR DESCRIPTION
They need separate permissions. The server key must be private and doesn't have a referrer restriction, the client key is public and must have a referrer restriction.