### PR TITLE
Logging of places response

### DIFF
--- a/higher_health/forms.py
+++ b/higher_health/forms.py
@@ -202,7 +202,8 @@ class HealthCheckQuestionnaire(forms.Form):
                     response = requests.get(
                         f"https://maps.googleapis.com/maps/api/place/details/json?{querystring}"
                     )
-                    geometry = response.json()["result"]["geometry"]["location"]
+                    place_details = response.json()
+                    geometry = place_details["result"]["geometry"]["location"]
                     data["latitude"] = geometry["lat"]
                     data["longitude"] = geometry["lng"]
                 else:

--- a/higher_health/tests/test_views.py
+++ b/higher_health/tests/test_views.py
@@ -431,6 +431,30 @@ class QuestionnaireTest(TestCase):
             ],
         )
 
+    @responses.activate
+    def test_post_google_places_lookup_error(self):
+        data = get_data()
+        data["latitude"] = ""
+        data["longitude"] = ""
+        data["address"] = "area 51"
+
+        places_url = "https://maps.googleapis.com/maps/api/place/autocomplete/json?key=TEST_API_KEY&input=area+51&language=en&components=country%3Aza"
+
+        responses.add(
+            responses.GET, places_url, json={}, status=200, match_querystring=True
+        )
+
+        response = self.client.post(reverse("healthcheck_questionnaire"), data)
+
+        self.assertEqual(response.status_code, 200)
+        errors = response.context["form"].errors
+        self.assertEqual(
+            errors["address"],
+            [
+                "Sorry, we had a temporary error trying to validate this address, please try again"
+            ],
+        )
+
 
 class ReceiptTest(TestCase):
     def test_get_with_empty_session(self):


### PR DESCRIPTION
The second call from the places API is sometimes not returning what we expect it to return.

This PR places the response in a variable before interpreting it, so that the value of that variable appears in the sentry logs, so that we can see what it's returning, and then make a decision from that point on what to do about it