### PR TITLE
Fix static files cache headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ coverage.xml
 # Django stuff:
 *.log
 staticfiles/
+static/
 
 # Sphinx documentation
 docs/_build/

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -140,7 +140,7 @@ STATICFILES_FINDERS = (
 )
 
 
-STATIC_ROOT = join(ROOT_DIR, "staticfiles")
+STATIC_ROOT = join(ROOT_DIR, "static")
 STATIC_URL = "/static/"
 COMPRESS_ENABLED = True
 


### PR DESCRIPTION
Our django base image sets long expiry cache headers for static files with hashes in their names. But this only works if the files are in `/static/`, not in `/staticfiles/`.

This PR fixes that, so that we have proper caching on static files