### PR TITLE
Fix submission of age value to eventstore

### DIFF
--- a/higher_health/tasks.py
+++ b/higher_health/tasks.py
@@ -33,7 +33,7 @@ def submit_healthcheck_to_eventstore(healthcheck_id: Text) -> None:
         "source": healthcheck.source,
         "province": healthcheck.province,
         "city": healthcheck.city,
-        "age": healthcheck.age,
+        "age": {"18-39": "18-40"}.get(healthcheck.age, healthcheck.age),
         "date_of_birth": (
             healthcheck.date_of_birth.isoformat() if healthcheck.date_of_birth else None
         ),

--- a/higher_health/tests/test_tasks.py
+++ b/higher_health/tests/test_tasks.py
@@ -179,3 +179,25 @@ class SubmitHealthCheckToEventStoreTests(TestCase):
                 },
             },
         )
+
+    @responses.activate
+    def test_age(self):
+        """
+        Submits correct age value for 18-40
+        """
+        responses.add(
+            method=responses.POST,
+            url="https://eventstore-placeholder/api/v3/covid19triage/",
+        )
+        data = get_data()
+        data["risk_level"] = get_risk_level(data)
+        user = User.objects.create_user("27820001001")
+
+        healthcheck = save_data(data, user)
+        healthcheck.age = "18-39"
+        healthcheck.save()
+        submit_healthcheck_to_eventstore(str(healthcheck.id))
+
+        call = responses.calls[-1]
+        request_data = json.loads(call.request.body)
+        self.assertEqual(request_data["age"], "18-40")


### PR DESCRIPTION
Even though there's a list of `choices` on the model, they're not being obeyed when listing the values and storing them to the database, so we need to send `18-40` when `18-39` is stored in the database