### PR TITLE
Separate FE and BE sentry configs

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -131,9 +131,11 @@ USE_TZ = True
 GA_TAG_KEYS = env.list("GOOGLE_GA_TAG_KEYS", default=[])
 
 SENTRY_DSN = env.str("SENTRY_DSN", "")
-if SENTRY_DSN:
+FE_SENTRY_DSN = env.str("FE_SENTRY_DSN", default=SENTRY_DSN)
+BE_SENTRY_DSN = env.str("BE_SENTRY_DSN", default=SENTRY_DSN)
+if BE_SENTRY_DSN:
     sentry_sdk.init(
-        dsn=SENTRY_DSN,
+        dsn=BE_SENTRY_DSN,
         integrations=[DjangoIntegration(), CeleryIntegration()],
         send_default_pii=True,
     )

--- a/higher_health/context_processors.py
+++ b/higher_health/context_processors.py
@@ -10,4 +10,4 @@ def ga_tags(request):
 
 
 def sentry_connect(request):
-    return {"SENTRY_DSN": settings.SENTRY_DSN}
+    return {"SENTRY_DSN": settings.FE_SENTRY_DSN}


### PR DESCRIPTION
This allows us to configure front end and back end sentry DSNs separately, so that we can alert on back end errors, but not alert on the noisy front end errors